### PR TITLE
Add a classic modal

### DIFF
--- a/src/components/ClassicModal/index.tsx
+++ b/src/components/ClassicModal/index.tsx
@@ -1,0 +1,89 @@
+import { ReactNode } from 'react'
+
+interface ClassicModalProps {
+  show: boolean
+  title: string
+  body: ReactNode
+  secondButtonText?: string
+  secondButtonAction?: () => void
+  closeModal: () => void
+}
+
+export const ClassicModal = ({
+  show,
+  title,
+  body,
+  secondButtonText,
+  secondButtonAction,
+  closeModal
+}: ClassicModalProps) => {
+  return (
+    <>
+      {show && (
+        <div
+          className="fixed z-10 inset-0 overflow-y-auto"
+          aria-labelledby="modal-title"
+          role="dialog"
+          aria-modal="true"
+        >
+          <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+            <div
+              className={`fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity ${
+                show ? 'animate-modalBgShow' : 'animate-modalBgOut'
+              }`}
+              aria-hidden="true"
+            ></div>
+            <span
+              className="hidden sm:inline-block sm:align-middle sm:h-screen "
+              aria-hidden="true"
+            >
+              &#8203;
+            </span>
+            <div
+              className={`inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full ${
+                show ? 'animate-modalPanelShow' : 'animate-modalPanelOut'
+              }
+            `}
+            >
+              <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                <div className="sm:flex sm:items-start">
+                  <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+                    <h3
+                      className="text-lg leading-6 font-medium text-gray-900"
+                      id="modal-title"
+                    >
+                      {title}
+                    </h3>
+                    <div className="mt-2 text-gray-900">
+                      {/* BODY SECTION */}
+                      {body}
+                      {/* FINISH BODY SECTION */}
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+                <button
+                  onClick={closeModal}
+                  type="button"
+                  className="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:ml-3 sm:w-auto sm:text-sm"
+                >
+                  Fechar
+                </button>
+                {secondButtonText && (
+                  <button
+                    onClick={secondButtonAction}
+                    type="button"
+                    className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
+                  >
+                    {secondButtonText}
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,42 @@ module.exports = {
     './src/components/**/*.{js,ts,jsx,tsx}'
   ],
   theme: {
+    keyframes: {
+      modalBgShow: {
+        '0%': { opacity: '0' },
+        '100%': { opacity: '1' }
+      },
+      modalBgOut: {
+        '100%': { opacity: '1' },
+        '0%': { opacity: '0' }
+      },
+      modalPanelShow: {
+        '0%': {
+          opacity: '0',
+          transform: ' scale(.95)'
+        },
+        '100%': {
+          opacity: '1',
+          transform: 'scale(1)'
+        }
+      },
+      modalPanelOut: {
+        '100%': {
+          opacity: '1',
+          transform: 'scale(.95)'
+        },
+        '0%': {
+          opacity: '0',
+          transform: 'scale(1)'
+        }
+      }
+    },
+    animation: {
+      modalBgShow: 'modalBgShow 300ms ease-out',
+      modalBgOut: 'modalBgOut 200ms ease-in',
+      modalPanelShow: 'modalPanelShow 300ms ease-out',
+      modalPanelOut: 'modalPanelOut 200ms ease-in'
+    },
     extend: {
       backgroundImage: {
         pattern: `url('/assets/fbPattern.svg')`


### PR DESCRIPTION
## Summary

This PR add a new ClassicModal component, based on TailWindCSS and you can add a second button. For a while we cant click out-side the modal to close it. Another change will add a click-out-site hook.

```jsx
// Import that way
import { ClassicModal } from 'components/ClassicModal'

 // On using this component, make a state on parent elemnt and attribuite to the ClassicModal
 const [showModal, setShowModal] = useState(false)

          <ClassicModal
            title="Teste"
            body="Isso pode ser JSX, com h1s, botões e etc"
            show={showModal}
            closeModal={() => {
              setShowModal(prevState => !prevState)
            }}
            // If you want a second button, add this two other props down below.
            // IMPORTANT: Create a function for this second button action.
            secondButtonText="Editar"
            secondButtonAction={() => handleSecondButton}
          />
          <button onClick={() => setShowModal(prevState => !prevState)}>
            Exibir modal
          </button>
```
